### PR TITLE
Updated to work with latest intellij versions

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,9 +4,11 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="delegatedBuild" value="true" />
+        <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="#JAVA_HOME" />
+        <option name="gradleJvm" value="17" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ pluginVersion = 0.2.1
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 211
-pluginUntilBuild = 222.*
+pluginUntilBuild = 233.*
 # last version on Java 11, then 222 -> 2022.2 Java 17 required
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties


### PR DESCRIPTION
Updated the pluginUntilBuild value to allow for use with 2023.3.* releases of intellij
<img width="1512" alt="image" src="https://github.com/SolaceLabs/solace-intellij-plugin/assets/4515663/53814d53-007f-4e5c-ac7e-ce9934444b99">
